### PR TITLE
(update) Move Time Period and Network Confirmations to Advanced Settings

### DIFF
--- a/edd-blockonomics.php
+++ b/edd-blockonomics.php
@@ -659,6 +659,58 @@ class EDD_Blockonomics
 </script>
 ';
 
+    $advanced_settings = '<p id="advanced_title" class="bnomics-options-bold"><a href="javascript:show_advanced()">'.__('Advanced Settings', 'edd-blockonomics').'&#9660;</a></p>
+      <div id="advanced_window" style="display:none">
+        <p class="bnomics-options-bold"><a href="javascript:show_basic()">'.__('Advanced Settings', 'blockonomics-bitcoin-payments').' &#9650;</a></p>
+        <table class="form-table">
+          <tbody>
+          </tbody>
+        </table>
+      </div>
+      <script>
+        let advanced_window = document.getElementById("advanced_window");
+        let advanced_title = document.getElementById("advanced_title");
+
+        function show_advanced() {
+          advanced_title.style.display = "none";
+          advanced_window.style.display = "block";
+        }
+        function show_basic() {
+          advanced_title.style.display = "block";
+          advanced_window.style.display = "none";
+        }
+
+        function getParentRow(ele) {
+          let parent_container = ele
+          do {
+            parent_container = parent_container.parentNode
+          } while(!parent_container.matches("tr") && parent_container !== document.body )
+          return parent_container
+        }
+
+        let advanced_settings = document.querySelectorAll(".edd-blockonomics-advanced");
+        let advanced_row_container = document.querySelector("#advanced_window .form-table tbody");
+        
+        // Move advanced settings to the new container
+        advanced_settings.forEach(setting => {
+          let parentRow = getParentRow(setting);
+          advanced_row_container.appendChild(parentRow);
+        });
+        
+        document.addEventListener("DOMContentLoaded", function(event) {
+          // Once DOM is initialized
+          
+          // Fix for UI
+  
+          // Add colspan to container for full width
+          advanced_window.parentElement.setAttribute("colspan", "2");
+          // Remove empty <td> to empty space
+          advanced_window.parentElement.parentElement.children[1].remove();
+       
+       });
+      </script>
+    ';
+
     $blockonomics_settings = array(
       array(
         'id'      => 'edd_blockonomics_api_key',
@@ -681,7 +733,8 @@ class EDD_Blockonomics
           '20' => '20',
           '25' => '25',
           '30' => '30'
-        )
+        ),
+        'field_class' => 'edd-blockonomics-advanced'
       ),
       array(
         'id'      => 'edd_blockonomics_confirmations',
@@ -691,7 +744,14 @@ class EDD_Blockonomics
           '2' => '2 (recommended)',
           '1' => '1',
           'zero' => '0'
-        )       
+        ),
+        'field_class' => 'edd-blockonomics-advanced'
+      ),
+      array(
+        'id'      => 'edd_blockonomics_advanced_settings',
+        'name'    => $advanced_settings,
+        'readonly' => true,
+        'type'    => 'advanced_settings',
       ),
       array(
         'id'      => 'edd_blockonomics_testsetup',
@@ -724,6 +784,11 @@ class EDD_Blockonomics
 
 /*Call back method for the setting 'testsetup'*/
 function edd_testsetup_callback()
+{
+  printf("");
+}
+
+function edd_advanced_settings_callback()
 {
   printf("");
 }

--- a/edd-blockonomics.php
+++ b/edd-blockonomics.php
@@ -659,55 +659,32 @@ class EDD_Blockonomics
 </script>
 ';
 
-    $advanced_settings = '<p id="advanced_title" class="bnomics-options-bold"><a href="javascript:show_advanced()">'.__('Advanced Settings', 'edd-blockonomics').'&#9660;</a></p>
-      <div id="advanced_window" style="display:none">
-        <p class="bnomics-options-bold"><a href="javascript:show_basic()">'.__('Advanced Settings', 'blockonomics-bitcoin-payments').' &#9650;</a></p>
-        <table class="form-table">
-          <tbody>
-          </tbody>
-        </table>
-      </div>
+    $advanced_settings = '<p id="advanced_title_closed" class="bnomics-options-bold">
+        <a href="javascript:show_advanced()">'.__('Advanced Settings', 'edd-blockonomics').'&#9660;</a>
+      </p>
+      <p id="advanced_title_open" class="bnomics-options-bold">
+        <a href="javascript:show_basic()">'.__('Advanced Settings', 'blockonomics-bitcoin-payments').' &#9650;</a>
+      </p>
+      
       <script>
-        let advanced_window = document.getElementById("advanced_window");
-        let advanced_title = document.getElementById("advanced_title");
+        let advanced_title_closed = document.getElementById("advanced_title_closed");
+        let advanced_title_open = document.getElementById("advanced_title_open");
 
         function show_advanced() {
-          advanced_title.style.display = "none";
-          advanced_window.style.display = "block";
+          advanced_title_closed.style.display = "none";
+          advanced_title_open.style.display = "block";
+          document.querySelectorAll(".edd-blockonomics-advanced").forEach(ele => ele.style.display = "table-row");
         }
         function show_basic() {
-          advanced_title.style.display = "block";
-          advanced_window.style.display = "none";
+          advanced_title_closed.style.display = "block";
+          advanced_title_open.style.display = "none";
+          document.querySelectorAll(".edd-blockonomics-advanced").forEach(ele => ele.style.display = "none");
         }
 
-        function getParentRow(ele) {
-          let parent_container = ele
-          do {
-            parent_container = parent_container.parentNode
-          } while(!parent_container.matches("tr") && parent_container !== document.body )
-          return parent_container
-        }
-
-        let advanced_settings = document.querySelectorAll(".edd-blockonomics-advanced");
-        let advanced_row_container = document.querySelector("#advanced_window .form-table tbody");
-        
-        // Move advanced settings to the new container
-        advanced_settings.forEach(setting => {
-          let parentRow = getParentRow(setting);
-          advanced_row_container.appendChild(parentRow);
-        });
-        
         document.addEventListener("DOMContentLoaded", function(event) {
-          // Once DOM is initialized
-          
-          // Fix for UI
-  
-          // Add colspan to container for full width
-          advanced_window.parentElement.setAttribute("colspan", "2");
-          // Remove empty <td> to empty space
-          advanced_window.parentElement.parentElement.children[1].remove();
-       
-       });
+          show_basic();
+        });
+
       </script>
     ';
 
@@ -724,6 +701,12 @@ class EDD_Blockonomics
         'type'    => 'text'
       ),
       array(
+        'id'      => 'edd_blockonomics_advanced_settings',
+        'name'    => $advanced_settings,
+        'readonly' => true,
+        'type'    => 'advanced_settings',
+      ),
+      array(
         'id'      => 'edd_blockonomics_payment_countdown_time',
         'name'    => __('Time period of countdown timer on payment page (in minutes)', 'edd-blockonomics'),
         'type'    => 'select',
@@ -734,7 +717,7 @@ class EDD_Blockonomics
           '25' => '25',
           '30' => '30'
         ),
-        'field_class' => 'edd-blockonomics-advanced'
+        'class' => 'edd-blockonomics-advanced'
       ),
       array(
         'id'      => 'edd_blockonomics_confirmations',
@@ -745,13 +728,7 @@ class EDD_Blockonomics
           '1' => '1',
           'zero' => '0'
         ),
-        'field_class' => 'edd-blockonomics-advanced'
-      ),
-      array(
-        'id'      => 'edd_blockonomics_advanced_settings',
-        'name'    => $advanced_settings,
-        'readonly' => true,
-        'type'    => 'advanced_settings',
+        'class' => 'edd-blockonomics-advanced'
       ),
       array(
         'id'      => 'edd_blockonomics_testsetup',


### PR DESCRIPTION
Closes #31 

Added Support for Advanced Settings Dropdown. To reduce complexity and building additional features, the fix works by moving rows of settings with `field_class` = `edd-blockonomics-advanced`, which can be specified in settings array, to `advanced-window` table.

Future options for Advanced Options can be added as normal settings array, and `field_class` can be added, the frontend script will automatically move them to relevant location.

2 additional fixes are applied to ensure UI consistency:
1. `<td>` from parent container of Advanced Settings is removed
2. `<th>` of parent container of Advanced settings is given colspan of 2

Screenshots:

Closed:
![image](https://user-images.githubusercontent.com/22245433/147630553-bae58be0-3fe7-47c2-9a72-a058c8d59f36.png)

Opened:
![image](https://user-images.githubusercontent.com/22245433/147630560-d1eaa307-bdcc-4103-99b8-2a0430d61d44.png)

DOM Structure:
![image](https://user-images.githubusercontent.com/22245433/147630598-6b1fd3ae-6179-417b-82ea-c39698a95fc9.png)
