### PR TITLE
Fix Payment Expired Reload Issue

### DIFF
--- a/edd-blockonomics.php
+++ b/edd-blockonomics.php
@@ -359,7 +359,25 @@ class EDD_Blockonomics
     if ($address)
     {
       header("Content-Type: application/json");
-      exit(json_encode($orders[$address]));
+
+      $order = $orders[$address];
+      $blockonomics = new BlockonomicsAPI;
+
+      if($order['status'] == -1) {
+        // Update Order Params untill payment is initiated.
+        
+        if($order['currency'] != 'BTC'){
+          $price = $blockonomics->get_price($order['currency']);
+        } else{
+          $price = 1;
+        }
+
+        $order['satoshi'] = intval(1.0e8*$order['value']/$price);
+        $orders[$address] = $order;
+        edd_update_option('edd_blockonomics_orders', $orders);
+      }
+
+      exit(json_encode($order));
     }
 
     try

--- a/order.php
+++ b/order.php
@@ -12,7 +12,7 @@
       </div>
       <!-- Payment Expired -->
       <div class="bnomics-order-expired-wrapper" ng-show="order.status == -3" ng-cloak>
-	<h3 class="warning bnomics-status-warning"><?=__('Payment Expired (Use the browser back button and try again)', 'edd-blockonomics')?></h3><br>
+      <h3 class="warning bnomics-status-warning"><?=__('Payment Expired (Please refresh the page to try again)', 'edd-blockonomics')?></h3><br>
       </div>
       <div class="bnomics-order-expired-wrapper" ng-show="order.status == -2" ng-cloak>
        <h3 class="warning bnomics-status-warning"><?=__('Paid order BTC amount is less than expected. Contact merchant', 'edd-blockonomics')?></h3><br>


### PR DESCRIPTION
- Change text asking the user to go to the previous page to try again when the timer expires.
- Update the latest price when the Order Data is fetched for new or unpaid orders during checkout. This helps when the payment expires and the user refreshes the page.