### PR TITLE
(add) Die with error message on incorrect secret

### DIFF
--- a/edd-blockonomics.php
+++ b/edd-blockonomics.php
@@ -425,6 +425,8 @@ class EDD_Blockonomics
       
           edd_update_option('edd_blockonomics_orders', $orders);
         }
+      } else {
+        die('Incorrect Secret');
       }
     }
     catch ( Blockonomics_Exception $e )


### PR DESCRIPTION
Adds a simple error message incase of incorrect secret or when secret is not configured.