### PR TITLE
(fix) Attempt to assign property "type" on null

### DIFF
--- a/edd-blockonomics.php
+++ b/edd-blockonomics.php
@@ -131,6 +131,7 @@ class EDD_Blockonomics
   
   public function edd_blockonomics_testsetup(){
       $setup_errors = $this->testSetup();
+      $return = new stdClass();
       if($setup_errors)
       {
         $return->type = 'error';


### PR DESCRIPTION

### Error Description

```
PHP Fatal error:  Uncaught Error: Attempt to assign property "type" on null in /Users/.../Local Sites/wordpress/app/public/wp-content/plugins/easy-digital-downloads-plugin-master/edd-blockonomics.php:142
Stack trace:
#0 /Users/.../Local Sites/wordpress/app/public/wp-includes/class-wp-hook.php(310): EDD_Blockonomics->edd_blockonomics_testsetup('')
#1 /Users/.../Local Sites/wordpress/app/public/wp-includes/class-wp-hook.php(334): WP_Hook->apply_filters('', Array)
#2 /Users/.../Local Sites/wordpress/app/public/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#3 /Users/.../Local Sites/wordpress/app/public/wp-admin/admin-ajax.php(188): do_action('wp_ajax_testset...')
#4 {main}
  thrown in /Users/.../Local Sites/wordpress/app/public/wp-content/plugins/easy-digital-downloads-plugin-master/edd-blockonomics.php on line 142
```

### Error Fix

Variable is initialized using standard stdClass to avoid this issue.

### Alternate fix

Convert the $return to an array and set keys accordingly.