### PR TITLE
WIP: Add BCH Support

### DIFF
--- a/css/order.css
+++ b/css/order.css
@@ -4,7 +4,7 @@
   display: flex;
 }
 
-.bnomics-order-info > div {
+.bnomics-order-info>div {
   padding-top: 5px;
   padding-bottom: 0;
 }
@@ -48,12 +48,13 @@
 .bnomics-qr {
   text-align: center !important;
   padding: 10px 10px 5px 10px;
-  width:180px;
+  width: 180px;
   margin: 0 auto;
   text-align: left;
 }
 
-.bnomics-amount-input, .bnomics-address-input {
+.bnomics-amount-input,
+.bnomics-address-input {
   padding: 2px 4px;
   font-weight: 600;
   margin-top: 5px;
@@ -62,12 +63,13 @@
   border: 1px solid #DDD;
   box-shadow: none;
   text-align: center;
-  padding:7px;
+  padding: 7px;
   cursor: pointer;
   margin-left: 0;
 }
 
-.bnomics-amount-input li, .bnomics-address-input li {
+.bnomics-amount-input li,
+.bnomics-address-input li {
   display: inline-block;
   list-style: none;
   margin-left: 5px;
@@ -75,16 +77,17 @@
 }
 
 .bnomics-grey {
-  color:grey;
+  color: grey;
 }
 
-.bnomics-address, .bnomics-amount{
+.bnomics-address,
+.bnomics-amount {
   margin-top: 10px;
 }
 
 .bnomics-display-error {
   animation: errorAnimation 0s 3s forwards;
-  height: 0; 
+  height: 0;
   width: 0;
   overflow: hidden;
   display: inline-block;
@@ -92,13 +95,18 @@
 }
 
 @keyframes errorAnimation {
-  to   { width:auto;height: auto; }
+  to {
+    width: auto;
+    height: auto;
+  }
 }
+
 /* Style for QR Code in NoJS mode */
 svg {
   width: 160px;
   margin: auto;
 }
+
 /* Mobile */
 @media screen and (max-width: 800px) {
   .bnomics-btc-info {
@@ -117,13 +125,14 @@ svg {
 /* ----- Select Crypto Styles ------*/
 @font-face {
   font-family: 'cryptos';
-  src:  url('../fonts/cryptos.woff') format('woff');
+  src: url('../fonts/cryptos.woff') format('woff');
   font-weight: normal;
   font-style: normal;
   font-display: block;
 }
 
-[class^="bnomics-icon-"], [class*=" bnomics-icon-"] {
+[class^="bnomics-icon-"],
+[class*=" bnomics-icon-"] {
   font-family: 'cryptos' !important;
   speak: never;
   font-style: normal;
@@ -143,13 +152,14 @@ svg {
 .bnomics-icon-bch:before {
   content: "\e900";
 }
+
 .bnomics-icon-btc:before {
   content: "\e901";
 }
 
 .bnomics-select-options {
-  cursor:pointer;
-  width:100%;
+  cursor: pointer;
+  width: 100%;
   display: block;
   height: 4.2em;
   margin-bottom: 10px !important;
@@ -164,21 +174,21 @@ svg {
 }
 
 .bnomics-select-container {
-/*padding-top is the space above crypto options on the select crypto page*/
+  /*padding-top is the space above crypto options on the select crypto page*/
   padding-top: 10vh;
-  text-align:center;
-  max-width:400px;
-  margin:auto;
+  text-align: center;
+  max-width: 400px;
+  margin: auto;
 }
 
-.bnomics-select-container table{
+.bnomics-select-container table {
   border-collapse: separate;
   border-spacing: 10px 0px;
   border: none;
 }
 
 .vertical-line {
-  border-left: 2px solid ;
+  border-left: 2px solid;
   height: 2em;
   display: flex;
   padding-left: 5%;
@@ -198,7 +208,7 @@ svg {
   display: inline-block;
   width: 70px;
   height: 70px;
-  border: 3px solid rgba(255,255,255,.3);
+  border: 3px solid rgba(255, 255, 255, .3);
   border-radius: 50%;
   border-top-color: #000;
   animation: spin 1s ease-in-out infinite;
@@ -206,17 +216,35 @@ svg {
 }
 
 @keyframes spin {
-  to { -webkit-transform: rotate(360deg); }
+  to {
+    -webkit-transform: rotate(360deg);
+  }
 }
+
 @-webkit-keyframes spin {
-  to { -webkit-transform: rotate(360deg); }
+  to {
+    -webkit-transform: rotate(360deg);
+  }
 }
+
 @keyframes errorAnimationSync {
-  to { height: 0; width: 0; overflow: hidden; padding: 0; }
+  to {
+    height: 0;
+    width: 0;
+    overflow: hidden;
+    padding: 0;
+  }
 }
+
 @-webkit-keyframes errorAnimationSync {
-  to { height: 0; width: 0; overflow: hidden; padding: 0; }
+  to {
+    height: 0;
+    width: 0;
+    overflow: hidden;
+    padding: 0;
+  }
 }
+
 /** Hide Panels by Default **/
 
 #blockonomics_checkout:not(.no-js) .bnomics-order-container .bnomics-order-panel,
@@ -235,7 +263,8 @@ svg {
   font-display: block;
 }
 
-[class^="blockonomics-icon-"], [class*=" blockonomics-icon-"] {
+[class^="blockonomics-icon-"],
+[class*=" blockonomics-icon-"] {
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: 'blockonomics-icons' !important;
   speak: never;
@@ -253,7 +282,8 @@ svg {
   font-size: 1.5em;
 }
 
-[class^="blockonomics-icon-"].spin::before, [class*=" blockonomics-icon-"].spin::before {
+[class^="blockonomics-icon-"].spin::before,
+[class*=" blockonomics-icon-"].spin::before {
   display: inline-block;
   animation-name: rotate;
   animation-duration: 2s;
@@ -265,6 +295,7 @@ svg {
   from {
     transform: rotate(0deg);
   }
+
   to {
     transform: rotate(360deg);
   }
@@ -294,12 +325,14 @@ svg {
 
 /* - Blockonomics Font Icons Ends -- */
 
-#bnomics-amount-copy, #bnomics-address-copy {
+#bnomics-amount-copy,
+#bnomics-address-copy {
   padding-left: 5px;
   padding-right: 5px;
 }
 
-#bnomics-show-qr, #bnomics-refresh {
+#bnomics-show-qr,
+#bnomics-refresh {
   padding-left: 5px;
 }
 
@@ -336,7 +369,7 @@ svg {
 }
 
 .bnomics-copy-container {
-  display:flex;
+  display: flex;
   align-items: center;
   position: relative;
 }

--- a/edd-blockonomics.php
+++ b/edd-blockonomics.php
@@ -525,7 +525,6 @@ class EDD_Blockonomics
         localStorage.setItem(\'blockonomics_run_testSetup\', 1);
         document.getElementById("submit").click();
       }
-      console.log(localStorage.getItem(\'blockonomics_run_testSetup\'));
       if (localStorage.getItem(\'blockonomics_run_testSetup\') == 1) {
         localStorage.removeItem(\'blockonomics_run_testSetup\')
         testSetupFunc();

--- a/edd-blockonomics.php
+++ b/edd-blockonomics.php
@@ -715,12 +715,12 @@ class EDD_Blockonomics
         'type'    => 'text'
       ),
       array(
-        'id'      => 'blockonomics_btc',
+        'id'      => 'edd_blockonomics_btc',
         'name'    =>  __('Bitcoin (BTC)', 'edd-blockonomics'),
         'type'    => 'checkbox',
       ),
       array(
-        'id'      => 'blockonomics_bch',
+        'id'      => 'edd_blockonomics_bch',
         'name'    =>  __("Bitcoin Cash (BCH)", 'edd-blockonomics'),
         'type'    => 'checkbox',
       ),

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -68,7 +68,7 @@ class BlockonomicsAPI
         if($crypto === 'btc'){
             $url = BlockonomicsAPI::PRICE_URL. "?currency=$currency";
         }else{
-            $url = BlockonomicsAPI::PRICE_URL. "?currency=$currency";
+            $url = BlockonomicsAPI::BCH_PRICE_URL. "?currency=$currency";
         }
         $response = $this->get($url);
         if (!isset($responseObj)) $responseObj = new stdClass();
@@ -81,13 +81,6 @@ class BlockonomicsAPI
         }
         return $responseObj->price;
     }
-
-    // public function get_xpubs($api_key)
-    // {
-    // 	$url = BlockonomicsAPI::ADDRESS_URL;
-    //     $response = $this->get($url, $api_key);
-    //     return json_decode(wp_remote_retrieve_body($response));
-    // }
 
     public function update_callback($callback_url, $crypto, $xpub)
     {   

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -265,7 +265,7 @@ class BlockonomicsAPI
         $active_currencies = array();
         $blockonomics_currencies = $this->getSupportedCurrencies();
         foreach ($blockonomics_currencies as $code => $currency) {
-            $enabled = edd_get_option('blockonomics_'.$code);
+            $enabled = edd_get_option('edd_blockonomics_'.$code);
             if($enabled || ($code === 'btc' && $enabled === false )){
                 $active_currencies[$code] = $currency;
             }

--- a/templates/blockonomics_crypto_options.php
+++ b/templates/blockonomics_crypto_options.php
@@ -1,0 +1,31 @@
+<?php
+$blockonomics = new BlockonomicsAPI;
+$cryptos = $blockonomics->getActiveCurrencies();
+$order_id = isset($_REQUEST["select_crypto"]) ? $_REQUEST["select_crypto"] : "";
+$order_url = $blockonomics->get_edd_url(array('show_order'=>$order_id))
+?>
+<div id="blockonomics_checkout">
+  <div class="bnomics-order-container">
+    <div class="bnomics-select-container">
+      <tr>
+        <?php
+        foreach ($cryptos as $code => $crypto) {
+          
+          $order_url = add_query_arg( array( 'crypto' => $code ), $order_url );
+        ?>
+          <a href="<?php echo $order_url;?>">
+            <button class="bnomics-select-options button">
+              <span class="bnomics-icon-<?php echo $code;?> bnomics-rotate-<?php echo $code;?>"></span>
+              <span class="vertical-line">
+                <?=__('Pay with', 'edd-blockonomics')?>
+                <?php echo $crypto['name'];?>
+              </span>
+            </button>
+          </a>
+        <?php 
+        }
+        ?>
+      </tr>
+    </div>
+  </div>
+</div>

--- a/templates/blockonomics_crypto_options.php
+++ b/templates/blockonomics_crypto_options.php
@@ -1,17 +1,13 @@
-<?php
-$blockonomics = new BlockonomicsAPI;
-$cryptos = $blockonomics->getActiveCurrencies();
-$order_id = isset($_REQUEST["select_crypto"]) ? $_REQUEST["select_crypto"] : "";
-$order_url = $blockonomics->get_edd_url(array('show_order'=>$order_id))
-?>
+<?php get_header();?>
+
 <div id="blockonomics_checkout">
   <div class="bnomics-order-container">
     <div class="bnomics-select-container">
       <tr>
         <?php
-        foreach ($cryptos as $code => $crypto) {
+        foreach ($context['cryptos'] as $code => $crypto) {
           
-          $order_url = add_query_arg( array( 'crypto' => $code ), $order_url );
+          $order_url = add_query_arg( array( 'crypto' => $code ), $context['order_url'] );
         ?>
           <a href="<?php echo $order_url;?>">
             <button class="bnomics-select-options button">
@@ -29,3 +25,5 @@ $order_url = $blockonomics->get_edd_url(array('show_order'=>$order_id))
     </div>
   </div>
 </div>
+
+<?php get_footer();?>

--- a/templates/blockonomics_no_crypto_selected.php
+++ b/templates/blockonomics_no_crypto_selected.php
@@ -1,0 +1,8 @@
+<div class="bnomics-order-container">
+    <h3>
+    No crypto currencies are enabled for checkout
+    </h3>
+    <p>
+    Note to webmaster: Can be enabled via Wordpress Admin > Settings > Blockonomics > Currencies
+    </p>
+</div>

--- a/templates/blockonomics_no_crypto_selected.php
+++ b/templates/blockonomics_no_crypto_selected.php
@@ -1,8 +1,8 @@
+<?php get_header();?>
+
 <div class="bnomics-order-container">
-    <h3>
-    No crypto currencies are enabled for checkout
-    </h3>
-    <p>
-    Note to webmaster: Can be enabled via Wordpress Admin > Settings > Blockonomics > Currencies
-    </p>
+    <h3><?= __('No crypto currencies are enabled for checkout', 'blockonomics-bitcoin-payments') ?></h3>
+    <p><?= __('Note to webmaster: Can be enabled via Wordpress Admin > Settings > Blockonomics', 'blockonomics-bitcoin-payments') ?></p>
 </div>
+
+<?php get_footer();?>


### PR DESCRIPTION
This PR makes some major changes and also adds support for BCH.

### Major changes:
1. Support for BCH
2. Order ID encryption, changes the way the entire system works by removing the addr parameter from URLs and replacing it with encrypted order ids.
3. Test Setup now uses save and reload mechanism using local storage to save before testing.
 
P.S. The PR is still under testing and code review.

### Currently Known Issues:

BCH Test Setup is giving error:
![image](https://github.com/blockonomics/easy-digital-downloads-plugin/assets/22245433/86b9a42e-95d5-4aec-8567-cab1b7a79950)

Error Messages and Label for test setup doesn't span whole width
