### PR TITLE
(add) Support for setting default values for settings

### DIFF
--- a/edd-blockonomics.php
+++ b/edd-blockonomics.php
@@ -849,22 +849,37 @@ class EDD_Blockonomics
 
   # Need to Discuss where to trigger this function for setting default values of admin settings
   public function set_default_values_admin_settings(){
+    global $blockonomics_edd_db_version;
     $settings_array = $this->get_settings_array();
     foreach ($settings_array as $setting){
       if (isset($setting['default']) && edd_get_option($setting['id']) === false){
         edd_update_option($setting['id'], $setting['default']);
       }
     }
+    update_option( 'blockonomics_edd_db_version', $blockonomics_edd_db_version );
   }
 
 }
 
+global $blockonomics_edd_db_version;
+$blockonomics_edd_db_version = '1.0';
+
+add_action( 'plugins_loaded', 'blockonomics_update_setting_check' );
 register_activation_hook( __FILE__, 'blockonomics_plugin_setup' );
+
+function blockonomics_update_setting_check() {
+  global $blockonomics_edd_db_version;
+  $installed_ver = get_site_option( 'blockonomics_edd_db_version' );
+  if (empty($installed_ver) || version_compare( $installed_ver, $blockonomics_edd_db_version, '!=')){
+    $edd_blockonomics = new EDD_Blockonomics;
+    $edd_blockonomics->set_default_values_admin_settings();
+  }
+}
 
 function blockonomics_plugin_setup() {
   if(!is_plugin_active('easy-digital-downloads/easy-digital-downloads.php'))
   {
-      trigger_error(__( 'Wordpress Bitcoin Payments - Blockonomics requires Easy Digital Downloads plugin to be installed and active.', 'edd-blockonomics' ).'<br>', E_USER_ERROR);
+      trigger_error(__( 'EDD Bitcoin Payments - Blockonomics requires Easy Digital Downloads plugin to be installed and active.', 'edd-blockonomics' ).'<br>', E_USER_ERROR);
   }
   $edd_blockonomics = new EDD_Blockonomics;
   $edd_blockonomics->set_default_values_admin_settings();

--- a/edd-blockonomics.php
+++ b/edd-blockonomics.php
@@ -851,20 +851,8 @@ class EDD_Blockonomics
   public function set_default_values_admin_settings(){
     $settings_array = $this->get_settings_array();
     foreach ($settings_array as $setting){
-      if($setting['class']){
-        if($setting['id'] == 'edd_blockonomics_timeperiod'){
-          if(edd_get_option($setting['id'], '10') === '10'){
-            edd_update_option($setting['id'], $setting['default']);
-          }
-        }elseif($setting['id'] == 'edd_blockonomics_margin' || $setting['id'] == 'edd_blockonomics_underpayment_slack'){
-          if(edd_get_option($setting['id'], 0) === 0){
-            edd_update_option($setting['id'], $setting['default']);
-          }
-        }elseif($setting['id'] == 'edd_blockonomics_confirmations'){
-          if(edd_get_option($setting['id'], 'zero') === 'zero'){
-            edd_update_option($setting['id'], $setting['default']);
-          }
-        }
+      if (isset($setting['default']) && !isset(edd_get_option($setting['id']))) {
+        edd_update_option($setting['id'], $setting['default'])
       }
     }
   }

--- a/edd-blockonomics.php
+++ b/edd-blockonomics.php
@@ -859,6 +859,17 @@ class EDD_Blockonomics
 
 }
 
+register_activation_hook( __FILE__, 'blockonomics_plugin_setup' );
+
+function blockonomics_plugin_setup() {
+  if(!is_plugin_active('easy-digital-downloads/easy-digital-downloads.php'))
+  {
+      trigger_error(__( 'Wordpress Bitcoin Payments - Blockonomics requires Easy Digital Downloads plugin to be installed and active.', 'edd-blockonomics' ).'<br>', E_USER_ERROR);
+  }
+  $edd_blockonomics = new EDD_Blockonomics;
+  $edd_blockonomics->set_default_values_admin_settings();
+}
+
 /*Call back method for the setting 'testsetup'*/
 function edd_testsetup_callback()
 {

--- a/edd-blockonomics.php
+++ b/edd-blockonomics.php
@@ -494,6 +494,13 @@ class EDD_Blockonomics
 
   public function settings( $settings )
   {
+    $blockonomics_settings = $this->get_settings_array();
+    $blockonomics_settings = apply_filters('edd_blockonomics_settings', $blockonomics_settings);
+    $settings['blockonomics'] = $blockonomics_settings;
+    return $settings;
+  }
+
+  public function get_settings_array(){
     $callback_update_url = add_query_arg(array( 'edd-listener' => 'blockonomics', 'action' => 'update_callback') ,home_url());
     $callback_refresh = __( 'CALLBACK URL', 'edd-blockonomics' ).'<a href="'.$callback_update_url.'"
       id="generate-callback" style="font:400 20px/1 dashicons;margin-left: 7px; top: 4px;position:relative;text-decoration: none;" title="Generate New Callback URL">&#xf463;<a>';
@@ -644,7 +651,7 @@ class EDD_Blockonomics
       </script>
     ';
 
-    $blockonomics_settings = array(
+    return array(
       array(
         'id'      => 'edd_blockonomics_api_key',
         'name'    => __( 'BLOCKONOMICS API KEY', 'edd-blockonomics' ),
@@ -673,14 +680,16 @@ class EDD_Blockonomics
           '25' => '25',
           '30' => '30'
         ),
-        'class' => 'edd-blockonomics-advanced'
+        'class' => 'edd-blockonomics-advanced',
+        'default' => '10'
       ),
       array(
         'id'      => 'edd_blockonomics_margin',
         'name'    => __('Extra Currency Rate Margin % (Increase live fiat to BTC rate by small percent)', 'edd-blockonomics'),
         'type'    => 'number',
         'max'     => 20,
-        'class' => 'edd-blockonomics-advanced'
+        'class' => 'edd-blockonomics-advanced',
+        'default' => 0
       ),
       array(
         'id'      => 'edd_blockonomics_confirmations',
@@ -691,14 +700,16 @@ class EDD_Blockonomics
           '1' => '1',
           'zero' => '0'
         ),
-        'class' => 'edd-blockonomics-advanced'
+        'class' => 'edd-blockonomics-advanced',
+        'default' => '2'
       ),
       array(
         'id'      => 'edd_blockonomics_underpayment_slack',
         'name'    => __('Underpayment Slack % (Allow payments that are off by a small percentage)', 'edd-blockonomics'),
         'type'    => 'number',
         'max'     => 20,
-        'class' => 'edd-blockonomics-advanced'
+        'class' => 'edd-blockonomics-advanced',
+        'default' => 0
       ),
       array(
         'id'      => 'edd_blockonomics_testsetup',
@@ -707,10 +718,6 @@ class EDD_Blockonomics
         'type'    => 'testsetup',
       )
     );
-
-    $blockonomics_settings = apply_filters('edd_blockonomics_settings', $blockonomics_settings);
-    $settings['blockonomics'] = $blockonomics_settings;
-    return $settings;
   }
 
   public function enqueue_stylesheets(){
@@ -839,6 +846,28 @@ class EDD_Blockonomics
     $blockonomics_orders[$address] = $order;
     edd_update_option('edd_blockonomics_orders', $blockonomics_orders);
   } 
+
+  # Need to Discuss where to trigger this function for setting default values of admin settings
+  public function set_default_values_admin_settings(){
+    $settings_array = $this->get_settings_array();
+    foreach ($settings_array as $setting){
+      if($setting['class']){
+        if($setting['id'] == 'edd_blockonomics_timeperiod'){
+          if(edd_get_option($setting['id'], '10') === '10'){
+            edd_update_option($setting['id'], $setting['default']);
+          }
+        }elseif($setting['id'] == 'edd_blockonomics_margin' || $setting['id'] == 'edd_blockonomics_underpayment_slack'){
+          if(edd_get_option($setting['id'], 0) === 0){
+            edd_update_option($setting['id'], $setting['default']);
+          }
+        }elseif($setting['id'] == 'edd_blockonomics_confirmations'){
+          if(edd_get_option($setting['id'], 'zero') === 'zero'){
+            edd_update_option($setting['id'], $setting['default']);
+          }
+        }
+      }
+    }
+  }
 
 }
 

--- a/edd-blockonomics.php
+++ b/edd-blockonomics.php
@@ -851,8 +851,8 @@ class EDD_Blockonomics
   public function set_default_values_admin_settings(){
     $settings_array = $this->get_settings_array();
     foreach ($settings_array as $setting){
-      if (isset($setting['default']) && !isset(edd_get_option($setting['id']))) {
-        edd_update_option($setting['id'], $setting['default'])
+      if (isset($setting['default']) && edd_get_option($setting['id']) === false){
+        edd_update_option($setting['id'], $setting['default']);
       }
     }
   }

--- a/edd-blockonomics.php
+++ b/edd-blockonomics.php
@@ -689,7 +689,7 @@ class EDD_Blockonomics
         'type'    => 'number',
         'max'     => 20,
         'class' => 'edd-blockonomics-advanced',
-        'default' => 0
+        'default' => 'zero'
       ),
       array(
         'id'      => 'edd_blockonomics_confirmations',
@@ -709,7 +709,7 @@ class EDD_Blockonomics
         'type'    => 'number',
         'max'     => 20,
         'class' => 'edd-blockonomics-advanced',
-        'default' => 0
+        'default' => 'zero'
       ),
       array(
         'id'      => 'edd_blockonomics_testsetup',
@@ -864,10 +864,11 @@ class EDD_Blockonomics
 global $blockonomics_edd_db_version;
 $blockonomics_edd_db_version = '1.0';
 
-add_action( 'plugins_loaded', 'blockonomics_update_setting_check' );
-register_activation_hook( __FILE__, 'blockonomics_plugin_setup' );
+add_action( 'plugins_loaded', 'edd_blockonomics_update_setting_check' );
+register_activation_hook( __FILE__, 'edd_blockonomics_plugin_setup' );
+add_filter('edd_update_option', 'edd_blockonomics_update_option_filter', 10, 2);
 
-function blockonomics_update_setting_check() {
+function edd_blockonomics_update_setting_check() {
   global $blockonomics_edd_db_version;
   $installed_ver = get_site_option( 'blockonomics_edd_db_version' );
   if (empty($installed_ver) || version_compare( $installed_ver, $blockonomics_edd_db_version, '!=')){
@@ -876,13 +877,22 @@ function blockonomics_update_setting_check() {
   }
 }
 
-function blockonomics_plugin_setup() {
+function edd_blockonomics_plugin_setup() {
   if(!is_plugin_active('easy-digital-downloads/easy-digital-downloads.php'))
   {
       trigger_error(__( 'EDD Bitcoin Payments - Blockonomics requires Easy Digital Downloads plugin to be installed and active.', 'edd-blockonomics' ).'<br>', E_USER_ERROR);
   }
   $edd_blockonomics = new EDD_Blockonomics;
   $edd_blockonomics->set_default_values_admin_settings();
+}
+
+function edd_blockonomics_update_option_filter($value, $key) {
+  if ($key === 'edd_blockonomics_underpayment_slack' || $key === 'edd_blockonomics_margin') {
+      if ($value === 'zero') {
+          $value = 0;
+      }
+  }
+  return $value;
 }
 
 /*Call back method for the setting 'testsetup'*/


### PR DESCRIPTION
Settings method has been refactored to add support for getting settings separately and accessible to other part of codes without passing through the EDD specific methods.

### What's remaining?
The method `set_default_values_admin_settings` can be called at one of the two places:
1. In the constructor same as where `generate_secret_and_callback` [method is called](https://github.com/blockonomics/easy-digital-downloads-plugin/blob/master/edd-blockonomics.php#L55). The problem with this approach is that the constructor is called everytime the plugin loads (not activate) while the method should be called only when the plugin activates.
2. We can add the [`register_activation_hook`](https://developer.wordpress.org/reference/functions/register_activation_hook/) for the plugin and load the settings there. But the problem being that activation might fail if EDD is not installed and also that it's not used anywhere in code to initialize the plugin yet.